### PR TITLE
Add option fir Unix/GNU CLI standard

### DIFF
--- a/include/CmdLineParser.h
+++ b/include/CmdLineParser.h
@@ -11,6 +11,10 @@
 #define CMDLINEPARSER_DEFAULT_FASCIST_MODE 1
 #endif
 
+#ifndef CMDLINEPARSER_DEFAULT_UNIXGNU_MODE
+#define CMDLINEPARSER_DEFAULT_UNIXGNU_MODE false
+#endif
+
 #include "string"
 #include "vector"
 #include "map"
@@ -29,13 +33,25 @@ public:
 
   void reset();
 
+  /**
+   * Check the legality of the arguments with the common Unix / GNU style.
+   * Options are expected to start with dash '-'.
+   * One character option starts with 1 dash, long options start with two dashes
+   * @param optionName_ the option itself including dashes
+   * @param nbExpectedVars_ number of expected vars
+   * @return Whether the option is suitable with Unix GNU standard
+   */
+  static bool checkOptionGNU(const std::vector<std::string>& optionName_, const int& nbExpectedVars_);
+
   //! Pre-parser
   void addTriggerOption(const std::string &optionName_, const std::vector<std::string> &commandLineCallStrList_, const std::string &description_ = "");
   void addOption(const std::string &optionName_, const std::vector<std::string> &commandLineCallStrList_, const std::string &description_ = "", int nbExpectedVars_ = 1);
   static void setIsFascist(bool isFascistParsing_); // if an extra/unrecognised arg is provided, you'll be punished with a logic error!
+  static void setIsUnixGNU(bool var);
 
   //! Parser / Init
   void parseCmdLine(int argc, char** argv);
+  void parseGNUcmdLine(int argc, char** argv);
 
   //! Pre/Post-parser
   bool isOptionDefined(const std::string& name_);
@@ -92,6 +108,7 @@ private:
 
 namespace CmdLineParserGlobals{
   static bool _fascistMode_ = CMDLINEPARSER_DEFAULT_FASCIST_MODE;
+  static bool _unixGnuMode_ = CMDLINEPARSER_DEFAULT_UNIXGNU_MODE;
 }
 
 #include "implementation/CmdLineParser.impl.h"

--- a/include/implementation/CmdLineParser.impl.h
+++ b/include/implementation/CmdLineParser.impl.h
@@ -34,12 +34,31 @@ void CmdLineParser::reset(){
   _isInitialized_ = false;
 }
 
+bool CmdLineParser::checkOptionGNU(const std::vector<std::string>& commandLineCallStrList_, const int& nbExpectedVars_) {
+    if (nbExpectedVars_ > 1)
+        throw std::logic_error("Unix GNU standard doesn't allow more then 1 option. Option: " + commandLineCallStrList_[0]);
+    for (const auto& option : commandLineCallStrList_){
+        if (option.length() < 2)
+            throw std::logic_error("Option must start with dash and contain at least 1 character. Option: " + option);
+
+        if (option[0] != '-')
+            throw std::logic_error("Option must start with dash. Option: " + option);
+
+        if (option.length() > 2 && option[1] != '-')
+            throw std::logic_error("Long option must start with two dashs. Option: " + option);
+    }
+
+    return true;
+}
+
 //! Pre-parser
 void CmdLineParser::addTriggerOption(const std::string &optionName_, const std::vector<std::string> &commandLineCallStrList_, const std::string &description_) {
   this->addOption(optionName_, commandLineCallStrList_, description_, 0);
 }
 void CmdLineParser::addOption(const std::string &optionName_, const std::vector<std::string> &commandLineCallStrList_, const std::string &description_, int nbExpectedVars_) {
   if( _isInitialized_ ){ throw std::logic_error("Can't add options while parseCmdLine has already been called"); }
+  if (CmdLineParserGlobals::_unixGnuMode_)
+      checkOptionGNU(commandLineCallStrList_, nbExpectedVars_);
   if( this->isOptionDefined(optionName_) ){
     throw std::logic_error("Option \"" + optionName_ + "\" has already been defined.");
   }
@@ -55,12 +74,79 @@ void CmdLineParser::setIsFascist(bool isFascistParsing_){
   CmdLineParserGlobals::_fascistMode_ = isFascistParsing_;
 }
 
+void CmdLineParser::setIsUnixGNU(bool var){
+    CmdLineParserGlobals::_unixGnuMode_ = var;
+}
+
+void CmdLineParser::parseGNUcmdLine(int argc, char** argv) {
+    for( int iArg = 0 ; iArg < argc ; iArg++ ) {
+        if( iArg == 0 ) _commandName_ = argv[iArg];
+        else _commandLineArgs_.emplace_back(argv[iArg]);
+    }
+
+    for (auto argIt = _commandLineArgs_.begin(); argIt != _commandLineArgs_.end(); ++argIt) {
+        if ((*argIt).length() < 2 || (*argIt)[0] != '-')
+            throw std::logic_error("Unix GNU standard doesn't allow more then 1 option. Option: " + (*argIt));
+
+        if ((*argIt)[1] != '-') {
+            // [list of] short option was found
+            // loop over each option in the argument
+            std::string optionWord = (*argIt).substr(1);
+            for (const auto& shortArg :  optionWord) {
+                std::cout << "-" + std::string(&shortArg).substr(0, 1) << std::endl;
+                std::cout << bool("-" + std::string(&shortArg).substr(0, 1) == "-i");
+                auto nextOpt = fetchOptionPtr("-" + std::string(&shortArg).substr(0, 1));
+                if (nextOpt == nullptr) {
+                    if (CmdLineParserGlobals::_fascistMode_)
+                        throw std::logic_error(&"Unrecognised option or value: " [ shortArg]);
+                    continue;
+                }
+
+                nextOpt->setIsTriggered(true);
+                if (nextOpt->getNbExpectedVars() == 0)
+                    continue;
+
+                // if the word is not over treat the rest of the word as an option value
+                if (optionWord.find(shortArg) != optionWord.length() - 1) {
+                    nextOpt->setNextVariableValue(optionWord.substr(optionWord.find(shortArg)+1));
+                    // done with the short option since no more chars to parse. Continue to next argument
+                    break;
+                } else {
+                    // end of line
+                    if (argIt == _commandLineArgs_.end() - 1) {
+                        throw std::logic_error("Option" + (*argIt).substr(0, 2) + "required a parameter, but nothing was found");
+                    }
+                    // take the next command line argument as a value
+                    nextOpt->setNextVariableValue(*(argIt + 1));
+                    ++argIt;
+                }
+            }
+        } else {
+            // long option was found
+            auto nextOpt = fetchOptionPtr((*argIt).substr(0, 2));
+            nextOpt->setIsTriggered(true);
+            if (nextOpt->getNbExpectedVars() == 0)
+                continue;
+            if (argIt == _commandLineArgs_.end() - 1) {
+                throw std::logic_error("Option" + (*argIt).substr(0, 2) + "required a parameter, but nothing was found");
+            }
+            nextOpt->setNextVariableValue(*(argIt + 1));
+            ++argIt;
+        }
+    }
+
+    _isInitialized_ = true;
+}
+
 //! Parser / Init
 void CmdLineParser::parseCmdLine(int argc, char** argv){
 
   if( _isInitialized_ ){
     throw std::logic_error("Can't parse cmd line args since it has already been called. Please do reset() before.");
   }
+
+  if (CmdLineParserGlobals::_unixGnuMode_)
+      return CmdLineParser::parseGNUcmdLine(argc, argv);
 
   for( int iArg = 0 ; iArg < argc ; iArg++ ){
     if( iArg == 0 ) _commandName_ = argv[iArg];

--- a/include/implementation/CmdLineParser.impl.h
+++ b/include/implementation/CmdLineParser.impl.h
@@ -119,16 +119,21 @@ void CmdLineParser::parseGNUcmdLine(int argc, char** argv) {
                     // take the next command line argument as a value
                     nextOpt->setNextVariableValue(*(argIt + 1));
                     ++argIt;
+                    continue;
                 }
             }
         } else {
             // long option was found
-            auto nextOpt = fetchOptionPtr((*argIt).substr(0, 2));
+            auto nextOpt = fetchOptionPtr((*argIt));
+            if (nextOpt == nullptr) {
+                if (CmdLineParserGlobals::_fascistMode_)
+                    throw std::logic_error("Unrecognised option or value: " + (*argIt));
+                continue;
             nextOpt->setIsTriggered(true);
             if (nextOpt->getNbExpectedVars() == 0)
                 continue;
             if (argIt == _commandLineArgs_.end() - 1) {
-                throw std::logic_error("Option" + (*argIt).substr(0, 2) + "required a parameter, but nothing was found");
+                throw std::logic_error("Option" + (*argIt) + "required a parameter, but nothing was found");
             }
             nextOpt->setNextVariableValue(*(argIt + 1));
             ++argIt;

--- a/include/implementation/CmdLineParser.impl.h
+++ b/include/implementation/CmdLineParser.impl.h
@@ -93,8 +93,6 @@ void CmdLineParser::parseGNUcmdLine(int argc, char** argv) {
             // loop over each option in the argument
             std::string optionWord = (*argIt).substr(1);
             for (const auto& shortArg :  optionWord) {
-                std::cout << "-" + std::string(&shortArg).substr(0, 1) << std::endl;
-                std::cout << bool("-" + std::string(&shortArg).substr(0, 1) == "-i");
                 auto nextOpt = fetchOptionPtr("-" + std::string(&shortArg).substr(0, 1));
                 if (nextOpt == nullptr) {
                     if (CmdLineParserGlobals::_fascistMode_)
@@ -124,14 +122,24 @@ void CmdLineParser::parseGNUcmdLine(int argc, char** argv) {
             }
         } else {
             // long option was found
-            auto nextOpt = fetchOptionPtr((*argIt));
+            auto eqPos = (*argIt).find('=');
+            auto searchPattern = (*argIt);
+            if (eqPos != std::string::npos)
+                searchPattern = searchPattern.substr(0, eqPos);
+            auto nextOpt = fetchOptionPtr(searchPattern);
             if (nextOpt == nullptr) {
                 if (CmdLineParserGlobals::_fascistMode_)
                     throw std::logic_error("Unrecognised option or value: " + (*argIt));
                 continue;
+            }
             nextOpt->setIsTriggered(true);
             if (nextOpt->getNbExpectedVars() == 0)
                 continue;
+            // separated with '='
+            if (eqPos != std::string::npos) {
+                nextOpt->setNextVariableValue((*argIt).substr(eqPos+1));
+                continue;
+            }
             if (argIt == _commandLineArgs_.end() - 1) {
                 throw std::logic_error("Option" + (*argIt) + "required a parameter, but nothing was found");
             }


### PR DESCRIPTION
Add optional support of [Unix/GNu CLI interface](https://www.gnu.org/prep/standards/html_node/Command_002dLine-Interfaces.html). That mostly inherits from standard POSIX, but with the extension for long options.

Since the standard is widely used by developers I expect such an option will enrich the package. E.g. GNU getopt/optatrg works exactly like that.

E.g.:
`./app.exe -abc` == `./app.exe -a -b -c`
`./app.exe -i../test.dat` == `./app.exe -i ../test.dat`
`./app.exe --input=../test.dat` == `./app.exe --input ../test.dat`

The main changes:
1. Check the option upon adding to CliParser with GNU standards 
2. Completely independent parser function in case GNU option is on.

So far, only implementation is done, w/o documentation and examples. If you found the PR positive, I can easily add examples before merging.